### PR TITLE
improve browser compatibility when onConnectExternal not supported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export function onConnect(init, responses, connections, onDisconnect) {
   }
 
   chrome.runtime.onConnect.addListener(onConnectListener);
-  chrome.runtime.onConnectExternal.addListener(onConnectListener);
+  if (chrome.runtime.onConnectExternal) chrome.runtime.onConnectExternal.addListener(onConnectListener);
 }
 
 export function connect(arg) {


### PR DESCRIPTION
I’ve got an `chrome.runtime.onConnectExternal is undefined` TypeError on Firefox.

Indeed, neither Firefox nor Edge support those events yet: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/onConnectExternal#Browser_compatibility

I guess few extensions actually rely on external messaging. As a matter of fact, those features aren’t high priorities on Web Extension API implementation roadmaps.

This won’t fix incomplete browser implementations, but at least such browsers are now able to run extensions with no external messaging.

I’m wondering if we should warn developers through the console though: 
> This browser doesn’t support chrome.runtime.onExternalConnect yet. Please be advised: if your extension does rely on external messaging, it will not work. Otherwise, you might ignore this message. See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/runtime/onConnectExternal#Browser_compatibility”